### PR TITLE
docs: Fix userdata directory name in local-access.mdx

### DIFF
--- a/content/docs/networking/local-access.mdx
+++ b/content/docs/networking/local-access.mdx
@@ -38,7 +38,7 @@ If you have **Developer Mode** enabled, you can reset the password by accessing 
 2. **Delete Config File and Reboot:**
 
 ```bash
-cd /user_data/           # Navigate to the user_data directory
+cd /userdata/            # Navigate to the userdata directory
 rm kvm_config.json       # Delete the configuration file containing the password
 sync                     # Ensure file changes are written to the file system
 reboot                   # Reboot the device


### PR DESCRIPTION
Rename `user_data` to `userdata` to match the actual directory name on device.

As tested on app 0.3.4, system 0.2.0.