### PR TITLE
docs: Fixed broken link to open source kvm repo

### DIFF
--- a/content/docs/getting-started/faq.mdx
+++ b/content/docs/getting-started/faq.mdx
@@ -31,7 +31,7 @@ solution to access it remotely, if you'd rather not use the cloud.
 
 **Absolutely!**
 
-The JetKVM project will be fully open sourced in the coming days, please see [the Open Source](open-source) page for
+The JetKVM project will be fully open sourced in the coming days, please see [the Open Source](https://github.com/jetkvm/kvm) page for
 more information about that specifically.
 
 You'll be able to run the device/user registry service yourself, it's a simple Node.JS Express based service. 
@@ -60,7 +60,7 @@ virtual keyboard to control your computer.
 
 **Not yet.** But don't worry, there isn't much text in the UI itself.
 
-There's an open feature request for UI localisation, and once the code is [made open source](open-source), the community
+There's an open feature request for UI localisation, and once the code is [made open source](https://github.com/jetkvm/kvm), the community
 will be able to contribute translations.
 
 ### Can JetKVM control power to the computer?


### PR DESCRIPTION
Replaced hyperlink references to the JetKVM open source repo with the github repo link. 