### PR TITLE
Automatically Update Copyright Year

### DIFF
--- a/app/components/landingpage/Footer.tsx
+++ b/app/components/landingpage/Footer.tsx
@@ -21,6 +21,7 @@ const FooterLink = ({
 );
 
 export default function Footer() {
+  const CurrentYear = new Date().getFullYear();
   return (
     <footer className="border-t border-t-slate-800/20 bg-white">
       <Container>
@@ -40,7 +41,7 @@ export default function Footer() {
           </div>
         </div>
         <div className="border-t border-t-slate-300 py-4 text-xs leading-none text-slate-500 md:text-sm">
-          © 2024 BuildJet, Inc. - All rights reserved.
+          © 2024-{CurrentYear} BuildJet, Inc. - All rights reserved.
         </div>
       </Container>
     </footer>


### PR DESCRIPTION
Added automatic year updating in the footer

Visual Look After Code Change:
<img width="1284" alt="image" src="https://github.com/user-attachments/assets/1dcd9b76-5365-4297-a37d-2a7b3bde69d0" />