### PR TITLE
docs(quick-start.mdx): fix typos & grammatical errors

### DIFF
--- a/content/docs/getting-started/quick-start.mdx
+++ b/content/docs/getting-started/quick-start.mdx
@@ -28,7 +28,7 @@ You can now control your target computer remotely.
 
 The front display of the JetKVM provides key information at a glance. Here’s what each section of the display shows:
 
-- **Device IP**: The IP address assigned to your by the network, allowing you to access the web UI.
+- **Device IP**: The IP address assigned to your device by the network, allowing you to access the web UI.
 - **Device MAC**: The unique MAC address of the device.
 - **Active Connections**: Displays the number of active connections currently in use.
 - **HDMI Cable Status**: Shows whether the HDMI connection to the target computer is active.
@@ -74,7 +74,7 @@ Let's make sure everything's safe before working inside your case.
 
 **2. Mount the ATX board in the case**
 
-Let’s physically install the board in a free slot. We include two bracket sizes, chose the one that fits your case the best.
+Let’s physically install the board in a free slot. We include two bracket sizes, choose the one that fits your case the best.
 
 1. **Pick any empty PCI/PCIe slot opening** (it doesn’t use electrical contacts, just mounting space).
 2. **Slide the board in** and secure the metal bracket with a screw.
@@ -82,7 +82,7 @@ Let’s physically install the board in a free slot. We include two bracket size
 #### 3. Connect ATX Extension to  motherboard
 Locate the `F_PANEL` header on your motherboard. It’s usually a small white or black 9- or 10-pin block labeled `F_PANEL`, `PANEL1`, or `FP1`.
 
-If you've previously connected your front panel controls to your motherboard, disconnect them from the motherboard now (we'll reconnect them  later).
+If you've previously connected your front panel controls to your motherboard, disconnect them from the motherboard now (we'll reconnect them later).
 
 Using your motherboard manual as a reference, **identify the specific layout and polarity of your motherboard pins** to match and connect it with the labels on the JetKVM ATX Board.
 


### PR DESCRIPTION
- add missing noun
- correct spelling
- remove extra space