### PR TITLE
Add 2nd optional argument for `ssh` config entry for Tailscale Install script for JetKVM. 

### DIFF
--- a/content/scripts/install-tailscale.sh
+++ b/content/scripts/install-tailscale.sh
@@ -12,7 +12,7 @@ main() {
 	SSH_CONFIG_NAME=""
 	AUTO_YES=false
 	CLEAN_INSTALL=false
-	POSITIONAL_COUNT=0
+
 
 	# Parse command line arguments
 	while [ $# -gt 0 ]; do
@@ -28,13 +28,16 @@ main() {
 		-c | --clean)
 			CLEAN_INSTALL=true
 			shift
+		-s | --ssh-config)
+			SSH_CONFIG_NAME="$2"
+			shift 1
 			;;
 		*)
-			POSITIONAL_COUNT=$((POSITIONAL_COUNT + 1))
-			if [ "$POSITIONAL_COUNT" -eq 1 ]; then
+			if [ -z "$JETKVM_IP" ]; then
 				JETKVM_IP="$1"
-			elif [ "$POSITIONAL_COUNT" -eq 2 ]; then
-				SSH_CONFIG_NAME="$1"
+			else
+				echo "ERROR: Unknown argument: $1"
+				exit 1
 			fi
 			shift
 			;;
@@ -51,21 +54,21 @@ main() {
 	if [ -z "$JETKVM_IP" ]; then
 		echo "ERROR: JetKVM IP address is required"
 		echo ""
-		echo "Usage: $0 [-v|--version <TAILSCALE_VERSION>] [-y|--yes] <JETKVM_IP> [SSH_CONFIG_NAME]"
+		echo "Usage: $0 [OPTIONS] <JETKVM_IP>"
 		echo ""
 		echo "Options:"
 		echo "  -v, --version    Specify Tailscale version (default: $TAILSCALE_VERSION)"
 		echo "  -y, --yes        Automatically answer yes to confirmation prompt"
 		echo "  -c, --clean      Delete any existing tailscale data (will cause a new machine to be created)"
+		echo "  -s, --ssh-config <NAME>     Name of SSH config entry to use instead of root@IP"
 		echo ""
 		echo "Arguments:"
-		echo "  JETKVM_IP        IP address of the JetKVM device (required)"
-		echo "  SSH_CONFIG_NAME  Name of SSH config entry to use (optional)"
+		echo "  JETKVM_IP                   IP address of the JetKVM device (required)"
 		echo ""
 		echo "Examples:"
 		echo "  $0 192.168.1.64"
-		echo "  $0 192.168.1.64 jetkvm"
-		echo "  $0 -v 1.88.1 -y 192.168.1.64 jetkvm"
+		echo "  $0 -s jetkvm 192.168.1.64"
+		echo "  $0 -v 1.88.1 -y -s jetkvm 192.168.1.64"
 		echo ""
 		echo "Default Tailscale version: $TAILSCALE_VERSION (first version to support JetKVM)"
 		exit 1


### PR DESCRIPTION
Add SSH Config arg (2nd after JETKVM_IP) to install-tailscale.sh, allowing you to use a public key that doesn't have to be the default convention. 

I have many keys on my machine, did not want to have to reuse `id_rsa` or any of the other defaults expected by this script. 

Assisted by Claude, reviewed/tested by me (a hooman).


```
❯ ./install-tailscale.sh 192.168.1.180 -s jetkvm
───────────────────────────────────────────────────────────
           JetKVM Tailscale Installation
───────────────────────────────────────────────────────────

  JetKVM IP:            192.168.1.180
  Tailscale Version:    1.88.1
  SSH Config:           jetkvm

  Note: The device will be rebooted during installation

Continue? [y/N]: y

[1/7] Checking if JetKVM device is reachable...
       Device is reachable
       Checking SSH access (Developer Mode)...
       SSH access confirmed
[2/7] Downloading Tailscale 1.88.1 checksum...
[3/7] Downloading Tailscale 1.88.1 package...
[4/7] Verifying package integrity...
       Package verification successful
[5/7] Transferring Tailscale package to JetKVM...
[6/7] Installing and configuring Tailscale on JetKVM...
       Extracting package...
       Configuring Tailscale for JetKVM...
       Rebooting JetKVM device...
       Waiting for JetKVM to reboot and come back online...
       Checking device status... (1/120s)
       Checking device status... (2/120s)
       Checking device status... (3/120s)
       Checking device status... (4/120s)
       Checking device status... (5/120s)
       Checking device status... (6/120s)
       Checking device status... (7/120s)
       JetKVM is back online with Tailscale installed!
[7/7] Starting Tailscale service...

To authenticate, visit:

        https://login.tailscale.com/a/xxxxxxxxx


```