### PR TITLE
Document JetKVM SDMMC microSD recovery

### DIFF
--- a/content/docs/advanced-usage/factory-reset.mdx
+++ b/content/docs/advanced-usage/factory-reset.mdx
@@ -1,28 +1,46 @@
 ---
 title: "Factory Reset"
-description: "Learn how to perform a factory reset on your JetKVM device using DFU Mode. This guide covers entering DFU Mode and flashing the latest firmware to restore your device to its original settings."
+description: "Restore your JetKVM to a clean firmware install. Use DFU mode for the original JetKVM, or write a recovery image to a microSD card for JetKVM SDMMC."
 order: 1
 ---
 
-If you need to reset your JetKVM device, this can be done by reflashing the firmware through DFU Mode (Device Firmware Update). This process restores the device by installing the latest firmware, effectively resetting it to factory settings. DFU Mode is essential when you can't access the KVM over SSH or want to start fresh with a clean firmware install.
+A factory reset reflashes JetKVM with the latest official firmware. Use it when you can't reach the device over SSH, want a clean slate, or are recovering from a failed boot.
 
-## Reset Your JetKVM Using DFU Mode
+The recovery procedure depends on which model you own:
 
-To reset the device, you will use DFU Mode, which allows you to flash the firmware directly to the KVM. Instead of compiling custom firmware, you will download the latest official firmware from the JetKVM GitHub repository.
+| Model          | Recovery method               | Image                |
+| -------------- | ----------------------------- | -------------------- |
+| JetKVM         | DFU mode + `upgrade_tool`     | `firmware.img`       |
+| JetKVM SDMMC   | Flash a microSD card          | `update_sd.img.zip`  |
 
-### Steps to Enter DFU Mode:
+Both images are served from the same endpoint, selected by the `sku` parameter shown in each section below.
+
+---
+
+## JetKVM: DFU recovery
+
+The original JetKVM is recovered over USB using DFU (Device Firmware Update) mode and Rockchip's `upgrade_tool`.
+
+### 1. Download the firmware
+
+Download the latest image from:
+
+```
+https://api.jetkvm.com/releases/system_recovery/latest?sku=jetkvm-v2
+```
+
+### 2. Enter DFU mode
 
 1. Unplug the USB cable from the device.
 2. Locate the small hole on the right side of the device.
-3. Insert a needle into the hole and press & hold the button inside before reconnecting the USB cable.
-4. Hold the needle for three seconds, then release. Your device is now in DFU Mode.
+3. Insert a needle into the hole, press and hold the button inside, then reconnect the USB cable.
+4. Hold for three seconds, then release. The device is now in DFU mode.
 
-## Flashing the Latest Firmware
+### 3. Flash the firmware
 
-Download the latest JetKVM firmware from [here](https://api.jetkvm.com/releases/system_recovery/latest).
+Pick the section for your operating system.
 
-
-### Linux
+#### Linux
 
 1. Clone the `rv1106-system` repository:
 
@@ -30,7 +48,7 @@ Download the latest JetKVM firmware from [here](https://api.jetkvm.com/releases/
 git clone https://github.com/jetkvm/rv1106-system.git
 ```
 
-2. Run the following command to flash the firmware:
+2. Flash the firmware:
 
 ```sh
 pushd tools/linux/Linux_Upgrade_Tool
@@ -38,11 +56,11 @@ sudo ./upgrade_tool uf /path/to/your/firmware.img
 popd
 ```
 
-### macOS
+#### macOS
 
 1. Download the [upgrade_tool](https://github.com/jetkvm/rv1106-system/releases/download/v0.2.5/upgrade_tool_v2.44_for_mac.zip) for macOS.
 
-2. Run the following command to flash the firmware:
+2. Flash the firmware:
 
 ```sh
 pushd upgrade_tool_v2.44_for_mac
@@ -50,30 +68,60 @@ sudo ./upgrade_tool uf /path/to/your/firmware.img
 popd
 ```
 
-### Windows
+#### Windows
 
-#### Install Drivers
+**Install drivers**
 
-1. Download [Driver Assistant](https://github.com/jetkvm/rv1106-system/releases/download/v0.2.5/DriverAssitant_v5.14.zip)
-
-2. Open Driver Assistant to install the drivers for the board. There's no need to connect the board to the computer during this step.
+1. Download [Driver Assistant](https://github.com/jetkvm/rv1106-system/releases/download/v0.2.5/DriverAssitant_v5.14.zip).
+2. Open Driver Assistant and install the drivers. The board does not need to be connected for this step.
 
 ![Driver Assistant](/content/files/dfu-driver-assistant.png)
 
-#### Flash the Firmware
+**Flash the firmware**
 
 1. Download and extract the [SocToolKit](https://github.com/jetkvm/rv1106-system/releases/download/v0.2.5/SocToolKit_v2.5_20250701_01_win.zip) for Windows.
-
-2. Open `SocToolKit.exe`, then select `RV1106`.
+2. Open `SocToolKit.exe` and select `RV1106`.
 
 ![SocToolKit](/content/files/dfu-soctoolkit-1.png)
 
-3. Enter your device into DFU Mode and connect the board to the computer.
-
-4. Navigate to the `Download` tab, check the `USB` radio then make sure the dropdown select is set to `Maskroom rockchip`.
-
-5. Click the `Firmware...` button, then select the firmware file you just downloaded.
-
-6. Click the `Upgrade` button to flash the firmware.
+3. Put the device in DFU mode and connect it to your computer.
+4. Open the `Download` tab, select the `USB` radio, and confirm the dropdown reads `Maskroom rockchip`.
+5. Click `Firmware...` and choose the firmware file you downloaded.
+6. Click `Upgrade` to flash.
 
 ![SocToolKit Complete](/content/files/dfu-soctoolkit-2.png)
+
+---
+
+## JetKVM SDMMC: microSD recovery
+
+JetKVM SDMMC boots from a microSD card. To recover the device, write a fresh recovery image to a card and boot from it.
+
+You will need:
+
+- A microSD card (8 GB or larger; UHS-I / Class 10 recommended)
+- An SD card image writer — [balenaEtcher](https://etcher.balena.io/), [Raspberry Pi Imager](https://www.raspberrypi.com/software/), or `dd` all work
+
+### 1. Download the recovery image
+
+Download `update_sd.img.zip` from:
+
+```
+https://api.jetkvm.com/releases/system_recovery/latest?sku=jetkvm-v2-sdmmc
+```
+
+The archive contains a raw `dd`-format image. Most GUI writers can flash it directly without extracting.
+
+### 2. Write the image to the microSD card
+
+Flash `update_sd.img.zip` to the microSD card with your image writer.
+
+> Writing the image will erase everything on the card. Confirm you've selected the correct device before continuing.
+
+### 3. Boot from the microSD card
+
+1. Disconnect power from JetKVM SDMMC.
+2. Insert the prepared microSD card into the device.
+3. Reconnect power.
+
+The device boots from the new image. Recovery is complete when the front display shows the device's IP address as normal.


### PR DESCRIPTION
The new JetKVM SDMMC SKU recovers via a microSD card rather than DFU, so the factory-reset page now branches by model and points at the SKU-aware `releases/system_recovery/latest` endpoint. Adds the `update_sd.img.zip` flow for SDMMC and keeps the existing `upgrade_tool` instructions for the original JetKVM.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; main risk is user confusion if the new model/URL instructions are incorrect.
> 
> **Overview**
> Updates the `Factory Reset` documentation to **branch recovery steps by JetKVM model**, introducing a new **JetKVM SDMMC microSD-based recovery flow** alongside the existing DFU/`upgrade_tool` process.
> 
> The page now points to **SKU-specific** `system_recovery/latest` download URLs (`jetkvm-v2` vs `jetkvm-v2-sdmmc`), adds required materials and safety warning for flashing microSD cards, and clarifies/expands Windows flashing steps for DFU recovery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ef190add9278cea02115faab7024174546a37fc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->